### PR TITLE
Reload issue solved- We stay on the same project (page) and dont go b…

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -6,6 +6,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { useProjects } from '../hooks/useProjects';
+import { clearProject } from '../utils/projectStorage';
 
 interface HeaderProps {
   selectedProjectKey: string | null;
@@ -52,9 +53,11 @@ export function Header({ selectedProjectKey, onProjectChange, isUpdating }: Head
         method: 'POST',
         credentials: 'include'
       });
+      clearProject();
       navigate('/', { replace: true });
     } catch (err) {
       console.error('Logout error:', err);
+      clearProject();
       navigate('/', { replace: true });
     }
   };

--- a/frontend/src/utils/projectStorage.ts
+++ b/frontend/src/utils/projectStorage.ts
@@ -1,0 +1,5 @@
+const KEY = 'selectedProjectKey';
+
+export const saveProject = (k: string) => localStorage.setItem(KEY, k);
+export const loadProject = () => localStorage.getItem(KEY);
+export const clearProject = () => localStorage.removeItem(KEY);


### PR DESCRIPTION
This pull request introduces functionality to persist the selected project across sessions using `localStorage`. Key changes include the addition of utility functions for project storage, updates to the `Dashboard` component to utilize these functions, and modifications to the `Header` component to clear the project on logout.

### Persistent Project Storage:

* [`frontend/src/utils/projectStorage.ts`](diffhunk://#diff-7eee45a66a229736e854e02cd282cca344548c3ee47c12b5dc434b064c6db9a3R1-R5): Added utility functions `saveProject`, `loadProject`, and `clearProject` to manage the selected project key in `localStorage`.

### Updates to `Dashboard` Component:

* [`frontend/src/pages/Dashboard.tsx`](diffhunk://#diff-7eabb6a1b28e1d41c3174ae90cbcc7e8b33aa661acb97f93893956415b7751d3L15-R34): Modified the `selectedProjectKey` state to initialize with the value from `loadProject()` and updated the logic to sync the selected project key with `localStorage` during project selection and API fetch. [[1]](diffhunk://#diff-7eabb6a1b28e1d41c3174ae90cbcc7e8b33aa661acb97f93893956415b7751d3L15-R34) [[2]](diffhunk://#diff-7eabb6a1b28e1d41c3174ae90cbcc7e8b33aa661acb97f93893956415b7751d3L89-R99)

### Updates to `Header` Component:

* [`frontend/src/components/Header.tsx`](diffhunk://#diff-c510609aa826d49ad460d88069bb38a03f4369437f399594f14aa6019327c9cdR9): Integrated the `clearProject` function to remove the stored project key from `localStorage` during the logout process. [[1]](diffhunk://#diff-c510609aa826d49ad460d88069bb38a03f4369437f399594f14aa6019327c9cdR9) [[2]](diffhunk://#diff-c510609aa826d49ad460d88069bb38a03f4369437f399594f14aa6019327c9cdR56-R60)…ack to the default one